### PR TITLE
fix: pakket aanmaken — leverancier validatie, status-logica en versie…

### DIFF
--- a/backend/apps/pakketten/serializers.py
+++ b/backend/apps/pakketten/serializers.py
@@ -115,9 +115,7 @@ class PakketCreateUpdateSerializer(serializers.ModelSerializer):
         # indien niet expliciet opgegeven in de payload.
         if "leverancier" not in validated_data:
             if not user.organisatie:
-                raise serializers.ValidationError(
-                    {"leverancier": "Leverancier is verplicht. Kies een organisatie."}
-                )
+                raise serializers.ValidationError({"leverancier": "Leverancier is verplicht. Kies een organisatie."})
             validated_data["leverancier"] = user.organisatie
         # Pakketten aangemaakt door de eigen leverancier worden direct actief;
         # pakketten aangemaakt namens een andere leverancier krijgen concept-status.

--- a/backend/apps/pakketten/serializers.py
+++ b/backend/apps/pakketten/serializers.py
@@ -114,9 +114,16 @@ class PakketCreateUpdateSerializer(serializers.ModelSerializer):
         # Gebruik de organisatie van de ingelogde gebruiker als leverancier
         # indien niet expliciet opgegeven in de payload.
         if "leverancier" not in validated_data:
+            if not user.organisatie:
+                raise serializers.ValidationError(
+                    {"leverancier": "Leverancier is verplicht. Kies een organisatie."}
+                )
             validated_data["leverancier"] = user.organisatie
-        # Pakketten aangemaakt door iemand die niet de leverancier is krijgen concept-status
-        if not (user.organisatie and user.organisatie == validated_data.get("leverancier")):
+        # Pakketten aangemaakt door de eigen leverancier worden direct actief;
+        # pakketten aangemaakt namens een andere leverancier krijgen concept-status.
+        if user.organisatie and user.organisatie == validated_data.get("leverancier"):
+            validated_data["status"] = Pakket.Status.ACTIEF
+        else:
             validated_data["status"] = Pakket.Status.CONCEPT
         return super().create(validated_data)
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,6 +12,8 @@ djangorestframework-simplejwt>=5.3,<6.0
 django-allauth>=65.0,<66.0
 django-otp>=1.5,<2.0
 qrcode>=7.4,<8.0
+cryptography>=42.0,<46.0
+cffi>=1.17,<2.0
 
 # Permissions
 django-guardian>=2.4,<3.0

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,5 +1,20 @@
 /** @type {import('next').NextConfig} */
 
+const { execSync } = require("child_process");
+
+// Haal de huidige git commit hash op bij build-tijd.
+// Valt terug op de COMMIT_SHA omgevingsvariabele (CI/CD) of "onbekend".
+function getCommitSha() {
+  if (process.env.COMMIT_SHA) return process.env.COMMIT_SHA;
+  try {
+    return execSync("git rev-parse --short HEAD").toString().trim();
+  } catch {
+    return "onbekend";
+  }
+}
+
+const COMMIT_SHA = getCommitSha();
+
 const isDev = process.env.NODE_ENV === "development";
 
 // Content Security Policy — strenger in productie, ruimer in development.
@@ -69,6 +84,11 @@ const securityHeaders = [
 
 const nextConfig = {
   output: "standalone",
+
+  // Maak de commit hash beschikbaar als omgevingsvariabele in de browser.
+  env: {
+    NEXT_PUBLIC_COMMIT_SHA: COMMIT_SHA,
+  },
 
   async headers() {
     return [

--- a/frontend/src/app/(dashboard)/aanbod/nieuw/page.tsx
+++ b/frontend/src/app/(dashboard)/aanbod/nieuw/page.tsx
@@ -89,12 +89,19 @@ export default function NieuwPakketPage() {
       const nieuwPakket = await aanmaak.mutateAsync(payload);
 
       // Stap 2: GEMMA-koppelingen instellen indien geselecteerd
+      // Fouten hier blokkeren de navigatie niet — pakket is al aangemaakt.
       if (gemmaIds.length > 0) {
         setIsSavingGemma(true);
         try {
           await api.put(`/api/v1/pakketten/${nieuwPakket.id}/gemma-componenten/`, {
             gemma_component_ids: gemmaIds,
           });
+        } catch {
+          // GEMMA-koppeling mislukt: toon waarschuwing maar ga toch verder
+          setApiError(
+            "Pakket aangemaakt, maar GEMMA-componenten konden niet worden opgeslagen. " +
+            "U kunt deze later instellen via 'Bewerken'."
+          );
         } finally {
           setIsSavingGemma(false);
         }

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -1,10 +1,17 @@
 export function Footer() {
+  const commitSha = process.env.NEXT_PUBLIC_COMMIT_SHA;
+
   return (
     <footer className="border-t border-gray-200 bg-white">
       <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         <div className="flex flex-col items-center justify-between gap-4 sm:flex-row">
           <p className="text-sm text-gray-500">
-            &copy; {new Date().getFullYear()} VNG Realisatie — Softwarecatalogus
+            &copy; {new Date().getFullYear()} VNG Realisatie &mdash; Softwarecatalogus
+            {commitSha && (
+              <span className="ml-2 font-mono text-xs text-gray-400" title="Versie (git commit)">
+                v{commitSha}
+              </span>
+            )}
           </p>
           <div className="flex gap-6">
             <a


### PR DESCRIPTION
…-indicator

- Backend: expliciete ValidationError als functioneel_beheerder geen leverancier opgeeft, en status ACTIEF als aanbod_beheerder eigen org als leverancier gebruikt
- Frontend: GEMMA-koppelingsstap los van pakket-create afhandelen zodat een fout daar de navigatie niet blokkeert (toont waarschuwing in plaats van 'Niet gevonden.')
- Footer: toont git commit hash (NEXT_PUBLIC_COMMIT_SHA) zodat zichtbaar is welke versie in de browser draait

https://claude.ai/code/session_01Mtceu2HmEbv1EH1JLjL9gf